### PR TITLE
Fix/use-correct-design-unit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imgly/psd-importer",
-  "version": "0.0.2",
+  "version": "0.0.3-rc.0",
   "module": "dist/browser.js",
   "types": "dist/browser.d.ts",
   "type": "module",

--- a/src/lib/psd-parser/index.ts
+++ b/src/lib/psd-parser/index.ts
@@ -57,6 +57,7 @@ interface Flags {
   enableTextVerticalAlignmentFix: boolean;
   enableTextOneLineAlignmentFix: boolean;
   enableTextTypefaceReachableCheck: boolean;
+  enableCreateHiddenLayers: boolean;
   groupsEnabled: boolean;
 }
 const FlagDefaults: Flags = {
@@ -65,6 +66,7 @@ const FlagDefaults: Flags = {
   enableTextOneLineAlignmentFix: false,
   enableTextVerticalAlignmentFix: true,
   enableTextTypefaceReachableCheck: true,
+  enableCreateHiddenLayers: false,
   groupsEnabled: false,
 };
 
@@ -124,6 +126,8 @@ export class PSDParser {
     if (psdNode.type === "Layer") {
       let layerBlockId: number;
 
+      if (psdNode.isHidden && !this.flags.enableCreateHiddenLayers) return;
+
       if (psdNode.text) {
         layerBlockId = await this.createTextBlock(this.page, psdNode);
       } else {
@@ -140,6 +144,10 @@ export class PSDParser {
             layerBlockId = this.applyParentClipMasks(psdNode, layerBlockId);
           }
         }
+      }
+      // if the layer is hidden, hide the block
+      if (psdNode.isHidden) {
+        this.engine.block.setVisible(layerBlockId, false);
       }
       // map the layers to their corresponding groups
       const groupId = (psdNode as unknown as PartialLayerFrame).layerFrame

--- a/src/lib/psd-parser/index.ts
+++ b/src/lib/psd-parser/index.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import type CreativeEngine from "@cesdk/engine";
 import {
   BlendMode,
@@ -18,6 +17,7 @@ import {
   PathRecord,
   TypeToolObjectSettingAliBlock,
 } from "@webtoon/psd/dist/interfaces";
+// @ts-ignore
 import opentype from "opentype.js";
 import { parseColor } from "./color";
 import type { TypefaceParams, TypefaceResolver } from "./font-resolver";
@@ -25,6 +25,7 @@ import defaultFontResolver from "./font-resolver";
 import { EncodeBufferToPNG } from "./image-encoder";
 import {
   PartialLayerFrame,
+  StyleSheetData,
   TextProperties,
   VectorBooleanTypeItem,
   VectorNumberTypeItem,
@@ -522,9 +523,9 @@ export class PSDParser {
         return { x: newX, y: newY };
       }
 
-      const topLeft = applyTransform(left, top, TySh, 1);
-      const topRight = applyTransform(right, top, TySh, 1);
-      const bottomLeft = applyTransform(left, bottom, TySh, 1);
+      const topLeft = applyTransform(left, top, TySh);
+      const topRight = applyTransform(right, top, TySh);
+      const bottomLeft = applyTransform(left, bottom, TySh);
 
       x = topLeft.x;
       y = topLeft.y;
@@ -577,7 +578,12 @@ export class PSDParser {
       // first character of the text content
       let textSectionStart = 0;
       // styleRunLengthArray contains the length of each text style run in characters
-      const styleRuns = styleRunLengthArray
+      interface StyleRun {
+        from: number;
+        to: number;
+        styleSheetData: StyleSheetData;
+      }
+      const styleRuns: StyleRun[] = styleRunLengthArray
         .map((len, index) => {
           const from = textSectionStart;
           const styleRun = textProperties.EngineDict?.StyleRun?.RunArray[index];
@@ -589,7 +595,7 @@ export class PSDParser {
           textSectionStart += len;
           return { from, to, styleSheetData };
         })
-        .filter((b) => b !== false);
+        .filter((b) => b !== false) as StyleRun[];
       styleRuns.forEach(({ from, to, styleSheetData }) => {
         // set text case
         const fontCaps = styleSheetData.FontCaps;

--- a/src/lib/psd-parser/index.ts
+++ b/src/lib/psd-parser/index.ts
@@ -26,6 +26,7 @@ import { EncodeBufferToPNG } from "./image-encoder";
 import {
   PartialLayerFrame,
   TextProperties,
+  VectorBooleanTypeItem,
   VectorNumberTypeItem,
   VectorObjectTypeItem,
   VectorPathRecordItem,
@@ -661,9 +662,9 @@ export class PSDParser {
         // "3": "Justified", // Justified is not supported in CE.SDK
       };
       const justificationValue = mapping[justification] ?? "Left";
-          this.engine.block.setEnum(
-            textBlock,
-            "text/horizontalAlignment",
+      this.engine.block.setEnum(
+        textBlock,
+        "text/horizontalAlignment",
         justificationValue
       );
     }
@@ -1397,14 +1398,13 @@ export class PSDParser {
         );
       }
       // set vector stroke data
-      this.engine.block.setStrokeEnabled(graphicBlock, true);
+      const strokeEnabledFlag = vstk.data.descriptor.items.get(
+        "strokeEnabled"
+      ) as VectorBooleanTypeItem;
+      this.engine.block.setStrokeEnabled(graphicBlock, strokeEnabledFlag.value);
       this.engine.block.setStrokeWidth(graphicBlock, strokeWidth.value);
-      this.engine.block.setStrokeColor(graphicBlock, {
-        r,
-        g,
-        b,
-        a: strokeOpacity.value / 100.0,
-      });
+      const color = { r, g, b, a: strokeOpacity.value / 100.0 };
+      this.engine.block.setStrokeColor(graphicBlock, color);
     }
     return graphicBlock;
   }

--- a/src/lib/psd-parser/index.ts
+++ b/src/lib/psd-parser/index.ts
@@ -570,18 +570,21 @@ export class PSDParser {
     if (styleRunLengthArray) {
       // first character of the text content
       let textSectionStart = 0;
+      // styleRunLengthArray contains the length of each text style run in characters
       const styleRuns = styleRunLengthArray
         .map((len, index) => {
           const from = textSectionStart;
-          const to = textSectionStart + len;
           const styleRun = textProperties.EngineDict?.StyleRun?.RunArray[index];
           const styleSheetData = styleRun?.StyleSheet?.StyleSheetData;
+          const isLast = index === styleRunLengthArray.length - 1;
+          const lastOffset = isLast ? -1 : 0;
+          const to = textSectionStart + len + lastOffset;
+          if (!styleSheetData || from >= to) return false;
           textSectionStart += len;
-          return { from, to, styleRun, styleSheetData };
+          return { from, to, styleSheetData };
         })
-        .filter(({ styleRun }) => styleRun);
-      // styleRunLengthArray contains the length of each text style run in characters
-      styleRuns.forEach(({ from, to, styleRun, styleSheetData }) => {
+        .filter((b) => b !== false);
+      styleRuns.forEach(({ from, to, styleSheetData }) => {
         // set text case
         const fontCaps = styleSheetData.FontCaps;
         if (fontCaps) {

--- a/src/lib/psd-parser/index.ts
+++ b/src/lib/psd-parser/index.ts
@@ -1341,7 +1341,8 @@ export class PSDParser {
       pathRecords,
       this.width,
       this.height,
-      -psdLayer.left / this.width,
+      // We need to apply the offset to the path records. This moves all points to the top left corner
+      -(psdLayer.left / this.width),
       -(psdLayer.top / this.height)
     );
 

--- a/src/lib/psd-parser/index.ts
+++ b/src/lib/psd-parser/index.ts
@@ -55,7 +55,6 @@ interface Flags {
   applyClipMasks: boolean;
   enableTextFitting: boolean;
   enableTextVerticalAlignmentFix: boolean;
-  enableTextOneLineAlignmentFix: boolean;
   enableTextTypefaceReachableCheck: boolean;
   enableCreateHiddenLayers: boolean;
   groupsEnabled: boolean;
@@ -63,7 +62,6 @@ interface Flags {
 const FlagDefaults: Flags = {
   applyClipMasks: true,
   enableTextFitting: true,
-  enableTextOneLineAlignmentFix: false,
   enableTextVerticalAlignmentFix: true,
   enableTextTypefaceReachableCheck: true,
   enableCreateHiddenLayers: false,
@@ -722,9 +720,6 @@ export class PSDParser {
     if (textBoxShape === "Auto" && this.flags.enableTextFitting) {
       await this.textFitting(textBlock);
     }
-    if (this.flags.enableTextOneLineAlignmentFix) {
-      this.enableTextOneLineAlignmentFix(textBlock);
-    }
     if (this.flags.enableTextVerticalAlignmentFix) {
       this.textVerticalAlignmentFix(textBlock);
     }
@@ -778,28 +773,6 @@ export class PSDParser {
     }
   }
 
-  // This should not be applied in multiple lines text
-  private enableTextOneLineAlignmentFix(textBlock: number) {
-    const fontSize = this.engine.block.getFloat(textBlock, "text/fontSize");
-    // Determine if text should be on one line based on frame height
-    const shouldBeOneLineText = (block: number): boolean => {
-      const frameHeight = this.engine.block.getFrameHeight(block);
-      // If frame height is less than twice the font size, it's likely a one-line text
-      return frameHeight < 2 * fontSize;
-    };
-    // Only if the text has a single line
-    if (shouldBeOneLineText(textBlock)) {
-      const frameHeight = this.engine.block.getFrameHeight(textBlock);
-      this.engine.block.setHeightMode(textBlock, "Auto");
-      const newFrameHeight = this.engine.block.getFrameHeight(textBlock);
-      // move block up by the difference
-      const diff = frameHeight - newFrameHeight;
-      const currentY = this.engine.block.getPositionY(textBlock);
-      this.engine.block.setPositionY(textBlock, currentY + diff);
-      this.engine.block.setHeightMode(textBlock, "Absolute");
-      this.engine.block.setHeight(textBlock, frameHeight);
-    }
-  }
   // Function to adjust text letter spacing up until a certain point to see if we can reduce a line
   private async textFitting(
     textBlock: number,

--- a/src/lib/psd-parser/index.ts
+++ b/src/lib/psd-parser/index.ts
@@ -631,7 +631,7 @@ export class PSDParser {
       "0": "Auto",
     };
     const textShapeType =
-      textProperties.EngineDict?.Rendered?.Shapes?.Children[0].TextShapeType;
+      textProperties.EngineDict?.Rendered?.Shapes?.Children[0].ShapeType;
     const textBoxShape = TEXT_SHAPE_TYPES[textShapeType] ?? "Fixed";
 
     // set the font size

--- a/src/lib/psd-parser/index.ts
+++ b/src/lib/psd-parser/index.ts
@@ -1434,16 +1434,30 @@ export class PSDParser {
 
     let svgPath = "";
     for (const record of pathRecords) {
-      // apply offsets:
+      // apply offsets and normalize values:
+      const normalize = (value: number) => {
+        // a 255 indicates a negative value
+        // get bitwise representation of the number
+        if (value < 200) {
+          return value;
+        }
+        return value - 256;
+      };
       if ("anchor" in record && record.anchor !== null) {
+        record.anchor.horiz = normalize(record.anchor.horiz);
+        record.anchor.vert = normalize(record.anchor.vert);
         record.anchor.horiz += offsetX;
         record.anchor.vert += offsetY;
       }
       if ("leaving" in record && record.leaving !== null) {
+        record.leaving.horiz = normalize(record.leaving.horiz);
+        record.leaving.vert = normalize(record.leaving.vert);
         record.leaving.horiz += offsetX;
         record.leaving.vert += offsetY;
       }
       if ("preceding" in record && record.preceding !== null) {
+        record.preceding.horiz = normalize(record.preceding.horiz);
+        record.preceding.vert = normalize(record.preceding.vert);
         record.preceding.horiz += offsetX;
         record.preceding.vert += offsetY;
       }

--- a/src/lib/psd-parser/index.ts
+++ b/src/lib/psd-parser/index.ts
@@ -79,7 +79,6 @@ export class PSDParser {
   private stack: number;
   private width: number;
   private height: number;
-  private scaleFactor: number;
   private page: number;
   private psd: Psd;
   private logger = new Logger();
@@ -124,6 +123,7 @@ export class PSDParser {
     // handle PSD node types
     if (psdNode.type === "Layer") {
       let layerBlockId: number;
+
       if (psdNode.text) {
         layerBlockId = await this.createTextBlock(this.page, psdNode);
       } else {

--- a/src/lib/psd-parser/index.ts
+++ b/src/lib/psd-parser/index.ts
@@ -1403,6 +1403,12 @@ export class PSDParser {
       const strokeEnabledFlag = vstk.data.descriptor.items.get(
         "strokeEnabled"
       ) as VectorBooleanTypeItem;
+      // get fill enabled flag
+      const fillEnabledFlag = vstk.data.descriptor.items.get(
+        "fillEnabled"
+      ) as VectorBooleanTypeItem;
+      // set fill enabled flag:
+      this.engine.block.setFillEnabled(graphicBlock, fillEnabledFlag.value);
       this.engine.block.setStrokeEnabled(graphicBlock, strokeEnabledFlag.value);
       this.engine.block.setStrokeWidth(graphicBlock, strokeWidth.value);
       const color = { r, g, b, a: strokeOpacity.value / 100.0 };

--- a/src/lib/psd-parser/index.ts
+++ b/src/lib/psd-parser/index.ts
@@ -573,7 +573,7 @@ export class PSDParser {
       const styleRuns = styleRunLengthArray
         .map((len, index) => {
           const from = textSectionStart;
-          const to = textSectionStart + len - 1;
+          const to = textSectionStart + len;
           const styleRun = textProperties.EngineDict?.StyleRun?.RunArray[index];
           const styleSheetData = styleRun?.StyleSheet?.StyleSheetData;
           textSectionStart += len;

--- a/src/lib/psd-parser/index.ts
+++ b/src/lib/psd-parser/index.ts
@@ -754,7 +754,6 @@ export class PSDParser {
 
   private textVerticalAlignmentFix(textBlock: number) {
     const fontSize = this.engine.block.getFloat(textBlock, "text/fontSize");
-    const fontSizeInDesignUnit = this.fontSizeToInches(fontSize);
     const fontUri = this.engine.block.getString(textBlock, "text/fontFileUri");
     const fontInfo = fontInfoMap[fontUri];
     if (fontInfo) {
@@ -762,7 +761,7 @@ export class PSDParser {
       const offset =
         (((-fontInfo.descender + fontInfo.ascender - fontInfo.unitsPerEm) /
           fontInfo.unitsPerEm) *
-          fontSizeInDesignUnit) /
+          fontSize) /
         2;
       this.moveTextInTextDirection(textBlock, 0, -offset);
     }
@@ -771,12 +770,11 @@ export class PSDParser {
   // This should not be applied in multiple lines text
   private enableTextOneLineAlignmentFix(textBlock: number) {
     const fontSize = this.engine.block.getFloat(textBlock, "text/fontSize");
-    const fontSizeInDesignUnit = this.fontSizeToInches(fontSize);
     // Determine if text should be on one line based on frame height
     const shouldBeOneLineText = (block: number): boolean => {
       const frameHeight = this.engine.block.getFrameHeight(block);
       // If frame height is less than twice the font size, it's likely a one-line text
-      return frameHeight < 2 * fontSizeInDesignUnit;
+      return frameHeight < 2 * fontSize;
     };
     // Only if the text has a single line
     if (shouldBeOneLineText(textBlock)) {
@@ -809,7 +807,6 @@ export class PSDParser {
     );
 
     const fontSize = this.engine.block.getFloat(textBlock, "text/fontSize");
-    const fontSizeInDesignUnit = this.fontSizeToInches(fontSize);
 
     // Function to check if the text block is overflowing
     // This is done by comparing the frame height in "auto" height mode to the real text block height
@@ -819,7 +816,7 @@ export class PSDParser {
     ): boolean => {
       const textBlockHeight = this.engine.block.getFrameHeight(textBlock);
       const isOverflowing =
-        textBlockHeight - realTextBlockHeight > fontSizeInDesignUnit / 2;
+        textBlockHeight - realTextBlockHeight > fontSize / 2;
       return isOverflowing;
     };
     const isPerfectFit = (
@@ -912,11 +909,6 @@ export class PSDParser {
     // Reset height to original
     this.engine.block.setHeightMode(textBlock, "Absolute");
     this.engine.block.setHeight(textBlock, originalHeight);
-  }
-
-  // Photoshop always uses 72 DPI for text size calculations
-  private fontSizeToInches(points: number): number {
-    return points / 72;
   }
 
   private getTextFontSet(textProperties: TextProperties): TypefaceParams {

--- a/src/lib/psd-parser/index.ts
+++ b/src/lib/psd-parser/index.ts
@@ -1240,10 +1240,10 @@ export class PSDParser {
     }
 
     // set layer position
-    this.engine.block.setPositionX(graphicBlock, x);
-    this.engine.block.setPositionY(graphicBlock, y);
-    this.engine.block.setWidth(graphicBlock, width);
-    this.engine.block.setHeight(graphicBlock, height);
+    this.engine.block.setPositionX(graphicBlock, psdLayer.left);
+    this.engine.block.setPositionY(graphicBlock, psdLayer.top);
+    this.engine.block.setWidth(graphicBlock, psdLayer.width);
+    this.engine.block.setHeight(graphicBlock, psdLayer.height);
 
     // apply rotation
     this.rotateBlock(graphicBlock, psdLayer);
@@ -1339,8 +1339,10 @@ export class PSDParser {
     // process path records
     let svgPath = this.buildShapeFromPathRecords(
       pathRecords,
-      psdLayer.width,
-      psdLayer.height
+      this.width,
+      this.height,
+      -psdLayer.left / this.width,
+      -(psdLayer.top / this.height)
     );
 
     // set the vector path's path data, width, and height
@@ -1410,9 +1412,11 @@ export class PSDParser {
   }
 
   private buildShapeFromPathRecords(
-    pathRecords: any,
+    pathRecords: PathRecord[],
     width: number,
-    height: number
+    height: number,
+    offsetX = 0,
+    offsetY = 0
   ) {
     let pathFillRule = false;
     let initialFillRule = false;
@@ -1423,6 +1427,20 @@ export class PSDParser {
 
     let svgPath = "";
     for (const record of pathRecords) {
+      // apply offsets:
+      if ("anchor" in record && record.anchor !== null) {
+        record.anchor.horiz += offsetX;
+        record.anchor.vert += offsetY;
+      }
+      if ("leaving" in record && record.leaving !== null) {
+        record.leaving.horiz += offsetX;
+        record.leaving.vert += offsetY;
+      }
+      if ("preceding" in record && record.preceding !== null) {
+        record.preceding.horiz += offsetX;
+        record.preceding.vert += offsetY;
+      }
+
       switch (record.type) {
         case PathRecordType.ClosedSubpathBezierKnotLinked:
         case PathRecordType.ClosedSubpathBezierKnotUnlinked:

--- a/src/lib/psd-parser/interfaces.ts
+++ b/src/lib/psd-parser/interfaces.ts
@@ -144,6 +144,11 @@ export interface VectorNumberTypeItem {
   value: number;
 }
 
+export interface VectorBooleanTypeItem {
+  type: string;
+  value: boolean;
+}
+
 export interface VectorObjectTypeItem {
   type: string;
   descriptor: {

--- a/src/lib/psd-parser/interfaces.ts
+++ b/src/lib/psd-parser/interfaces.ts
@@ -3,7 +3,7 @@ interface PsdColor {
   Type: number;
 }
 
-interface StyleSheetData {
+export interface StyleSheetData {
   DiacriticPos: number;
   Kashida: number;
   HindiNumbers: boolean;
@@ -74,7 +74,7 @@ interface ResourceDict {
   ParagraphSheetSet: Array<ParagraphSheet>;
 }
 
-interface StyleRunArrayItem {
+export interface StyleRunArrayItem {
   StyleSheet: {
     StyleSheetData: StyleSheetData;
   };

--- a/src/lib/psd-parser/utils.ts
+++ b/src/lib/psd-parser/utils.ts
@@ -33,27 +33,6 @@ export const webtoonToCesdkBlendMode: { [key: string]: BlendMode } = {
   lum: "Luminosity",
 };
 
-export function getDesignUnit(psd: Psd): DesignUnit {
-  if (psd.resolutionInfo?.horizontalUnit === 2) {
-    return "Millimeter";
-  }
-  return "Inch";
-}
-
-export function getScaleFactor(psd: Psd): number {
-  // default scale factor
-  let scaleFactor = 72;
-  if (!psd.resolutionInfo) return scaleFactor;
-
-  if (psd.resolutionInfo.horizontalUnit === 2) {
-    // convert PixelsPerCM to PixelsPerMM
-    return psd.resolutionInfo.horizontal * 10;
-  }
-
-  // PixelsPerInch
-  return psd.resolutionInfo?.horizontal;
-}
-
 export async function waitUntilBlockIsReady(
   engine: CreativeEngine,
   block: number,


### PR DESCRIPTION
Fixes multiple issues that could be observed in specific PSD files:
- Fix: Parse Stroke Visibility Setting
- Fix: Always use Pixel as design unit for designs. PSD files by design use Pixels for measurement.
- Fix: Parse Vector Color Fill Enabled Setting
- Fix: Vector paths with negative points