### PR TITLE
Fix regression with zero-dimension layers causing ImageData errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imgly/psd-importer",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "main": "dist/index.cjs",

--- a/src/lib/psd-parser/index.ts
+++ b/src/lib/psd-parser/index.ts
@@ -141,6 +141,15 @@ export class PSDParser {
       if (psdNode.isHidden && !this.flags.enableCreateHiddenLayers) return;
 
       await this.checkUnsupportedLayerFeatures(psdNode);
+      // Skip layers with zero width or height to prevent errors
+      if (psdNode.width <= 0 || psdNode.height <= 0) {
+        this.logger.log(
+          `Skipping layer "${psdNode.name}" with invalid dimensions: ${psdNode.width}x${psdNode.height}`,
+          "warning"
+        );
+        return; // Skip processing this layer entirely
+      }
+
       if (psdNode.text) {
         layerBlockId = await this.createTextBlock(page, psdNode);
       } else {


### PR DESCRIPTION
## Summary
- Fixed regression introduced between versions 0.0.7-0.0.8 where PSD files with zero-dimension layers caused "Pixel count must be a positive integer, got 0" errors
- Added validation to skip processing layers with width <= 0 or height <= 0 
- Added warning logging for skipped invalid layers

## Root Cause
The error occurred in the browser's `ImageData` constructor when `imageWidth` or `imageHeight` was 0. This regression was introduced with the switch from `@webtoon/psd` to `@imgly/psd` library, which appears to handle layer dimensions differently.

## Solution
Added early validation in `traverseNode()` method to skip processing layers with invalid dimensions before they reach the image encoding stage.

## Test Plan
- [x] Tested with the problematic `e3-aqua-gel.psd` file that was failing before
- [x] Verified the error no longer occurs and processing completes successfully
- [x] Confirmed warning messages are logged for skipped layers
- [x] Verified other functionality remains unaffected

## Files Changed
- `src/lib/psd-parser/index.ts`: Added dimension validation in `traverseNode()` method