### PR TITLE
Guard against null color in parseColor function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imgly/psd-importer",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "main": "dist/index.cjs",

--- a/src/lib/psd-parser/color.ts
+++ b/src/lib/psd-parser/color.ts
@@ -9,6 +9,8 @@ export function normalizeColorFloatValue(value: number): number {
 }
 
 export function parseColor(color: VectorObjectTypeItem): Color | null {
+  if (!color) return null;
+
   const redItem = color.descriptor.items.get("Rd  ") as VectorNumberTypeItem;
   const greenItem = color.descriptor.items.get("Grn ") as VectorNumberTypeItem;
   const blueItem = color.descriptor.items.get("Bl  ") as VectorNumberTypeItem;


### PR DESCRIPTION
## Summary
- Add null check guard in `parseColor` function to prevent crashes when color parameter is null

## Test plan
- [ ] Verify existing tests still pass
- [ ] Test with PSD files that might have null color values

🤖 Generated with [Claude Code](https://claude.ai/code)