### PR TITLE
fix: Don't apply rotation to layers with skew/shear transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.1] - 2025-01-16
+
+### Fixed
+
+- Don't apply rotation to layers with skew/shear transforms. Previously, layers with skew transforms would have incorrect rotation applied. Now the importer detects skew transforms and logs a warning instead of applying incorrect rotation.
+- Add guard against division by zero when processing degenerate transform matrices.
+- Fix warning message to be layer-type agnostic (applies to text, image, and graphic blocks).
+
+## [0.1.0] - 2025-01-10
+
+### Added
+
+- Use buffer URLs instead of blob URLs for transient resources.
+- WOFF2 font support.
+
+### Fixed
+
+- Handle capacity overflow errors when processing large layer masks.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imgly/psd-importer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "main": "dist/index.cjs",

--- a/src/lib/psd-parser/index.ts
+++ b/src/lib/psd-parser/index.ts
@@ -1730,7 +1730,7 @@ export class PSDParser {
       this.engine.block.setRotation(block, rotation);
     } else if (hasSkewTransform(transformXY, transformYX)) {
       this.logger.log(
-        `Layer '${psdLayer.name}' has a skew/shear transform which is not supported. The text will be rendered without skew.`,
+        `Layer '${psdLayer.name}' has a skew/shear transform which is not supported. The layer will be rendered without the skew transform.`,
         "warning"
       );
     }

--- a/src/lib/psd-parser/index.ts
+++ b/src/lib/psd-parser/index.ts
@@ -43,6 +43,10 @@ import {
   webtoonToCesdkBlendMode,
 } from "./utils";
 import { createBufferURL } from "./buffer-url";
+import {
+  extractRotationFromTransformMatrix,
+  hasSkewTransform,
+} from "./transform";
 
 /**
  * The pixel scale factor used in the CESDK Editor
@@ -638,7 +642,7 @@ export class PSDParser {
       this.engine.block.setBlendMode(textBlock, blendMode);
     }
     // apply rotation
-    this.rotateBlock(textBlock, psdLayer);
+    this.applyRotationFromTransform(textBlock, psdLayer);
 
     // set layer position
     this.engine.block.setWidth(textBlock, width);
@@ -1399,7 +1403,7 @@ export class PSDParser {
     this.engine.block.setHeight(imageBlock, height);
 
     // apply rotation
-    this.rotateBlock(imageBlock, psdLayer);
+    this.applyRotationFromTransform(imageBlock, psdLayer);
 
     return imageBlock;
   }
@@ -1454,7 +1458,7 @@ export class PSDParser {
     this.engine.block.setHeight(graphicBlock, psdLayer.height);
 
     // apply rotation
-    this.rotateBlock(graphicBlock, psdLayer);
+    this.applyRotationFromTransform(graphicBlock, psdLayer);
 
     // append the text block to the page
     this.engine.block.insertChild(pageBlock, graphicBlock, 0);
@@ -1709,13 +1713,26 @@ export class PSDParser {
     return svgPaths.join(" ");
   }
 
-  private rotateBlock(block: number, psdLayer: Layer): void {
+  private applyRotationFromTransform(block: number, psdLayer: Layer): void {
     const TySh = psdLayer.additionalProperties.TySh;
     if (!TySh) return;
 
-    const angleRadians = -Math.atan2(TySh.transformYX, TySh.transformXX);
-    if (angleRadians) {
-      this.engine.block.setRotation(block, angleRadians);
+    const { transformXX, transformXY, transformYX, transformYY } = TySh;
+
+    const rotation = extractRotationFromTransformMatrix(
+      transformXX,
+      transformXY,
+      transformYX,
+      transformYY
+    );
+
+    if (rotation !== null) {
+      this.engine.block.setRotation(block, rotation);
+    } else if (hasSkewTransform(transformXY, transformYX)) {
+      this.logger.log(
+        `Layer '${psdLayer.name}' has a skew/shear transform which is not supported. The text will be rendered without skew.`,
+        "warning"
+      );
     }
   }
 

--- a/src/lib/psd-parser/transform.test.ts
+++ b/src/lib/psd-parser/transform.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "bun:test";
+import {
+  extractRotationFromTransformMatrix,
+  hasSkewTransform,
+} from "./transform";
+
+describe("extractRotationFromTransformMatrix", () => {
+  it("should return null for identity matrix (no rotation)", () => {
+    const result = extractRotationFromTransformMatrix(1, 0, 0, 1);
+    expect(result).toBeNull();
+  });
+
+  it("should extract 90 degree rotation", () => {
+    // 90° rotation: cos(90°)=0, sin(90°)=1
+    // XX=0, XY=-1, YX=1, YY=0
+    const result = extractRotationFromTransformMatrix(0, -1, 1, 0);
+    expect(result).toBeCloseTo(-Math.PI / 2, 5);
+  });
+
+  it("should extract 45 degree rotation", () => {
+    const cos45 = Math.cos(Math.PI / 4);
+    const sin45 = Math.sin(Math.PI / 4);
+    // XX=cos, XY=-sin, YX=sin, YY=cos
+    const result = extractRotationFromTransformMatrix(
+      cos45,
+      -sin45,
+      sin45,
+      cos45
+    );
+    expect(result).toBeCloseTo(-Math.PI / 4, 5);
+  });
+
+  it("should extract rotation with uniform scale", () => {
+    const scale = 2;
+    const cos45 = Math.cos(Math.PI / 4);
+    const sin45 = Math.sin(Math.PI / 4);
+    const result = extractRotationFromTransformMatrix(
+      scale * cos45,
+      scale * -sin45,
+      scale * sin45,
+      scale * cos45
+    );
+    expect(result).toBeCloseTo(-Math.PI / 4, 5);
+  });
+
+  it("should return null for skew/shear transform", () => {
+    // Horizontal skew: XX=1, XY=0.5, YX=0, YY=1
+    const result = extractRotationFromTransformMatrix(1, 0.5, 0, 1);
+    expect(result).toBeNull();
+  });
+
+  it("should return null for non-uniform scale without rotation", () => {
+    // ScaleX=2, ScaleY=1, no rotation
+    const result = extractRotationFromTransformMatrix(2, 0, 0, 1);
+    expect(result).toBeNull();
+  });
+
+  it("should return null for degenerate matrix (zero scale)", () => {
+    const result = extractRotationFromTransformMatrix(0, 0, 0, 0);
+    expect(result).toBeNull();
+  });
+
+  it("should handle negative rotation (-30 degrees)", () => {
+    // For a -30° rotation matrix, the function returns +30° due to negation
+    const angle = -Math.PI / 6; // -30 degrees
+    const cos = Math.cos(angle);
+    const sin = Math.sin(angle);
+    const result = extractRotationFromTransformMatrix(cos, -sin, sin, cos);
+    // The function negates atan2 result, so -30° input matrix yields +30° output
+    expect(result).toBeCloseTo(-angle, 5);
+  });
+});
+
+describe("hasSkewTransform", () => {
+  it("should return false for identity (no XY/YX components)", () => {
+    expect(hasSkewTransform(0, 0)).toBe(false);
+  });
+
+  it("should return true when XY is non-zero", () => {
+    expect(hasSkewTransform(0.5, 0)).toBe(true);
+  });
+
+  it("should return true when YX is non-zero", () => {
+    expect(hasSkewTransform(0, 0.5)).toBe(true);
+  });
+
+  it("should return false for values within tolerance", () => {
+    expect(hasSkewTransform(0.0005, 0.0005)).toBe(false);
+  });
+
+  it("should return true for values just above tolerance", () => {
+    expect(hasSkewTransform(0.002, 0)).toBe(true);
+  });
+});

--- a/src/lib/psd-parser/transform.ts
+++ b/src/lib/psd-parser/transform.ts
@@ -27,6 +27,11 @@ export function extractRotationFromTransformMatrix(
     transformYY * transformYY + transformYX * transformYX
   );
 
+  // Guard against degenerate matrices (zero scale)
+  if (scaleX < 1e-10 || scaleY < 1e-10) {
+    return null;
+  }
+
   // Normalize the matrix components to remove scale
   const normalizedXX = transformXX / scaleX;
   const normalizedXY = transformXY / scaleX;

--- a/src/lib/psd-parser/transform.ts
+++ b/src/lib/psd-parser/transform.ts
@@ -1,0 +1,63 @@
+/**
+ * Extracts the rotation angle from a PSD transform matrix, if it represents a pure rotation.
+ * Returns null if the matrix contains skew/shear (which CE.SDK doesn't support).
+ *
+ * A 2D transform matrix has the form:
+ * | XX  XY  TX |
+ * | YX  YY  TY |
+ *
+ * For a pure rotation with scale:
+ * - XX = scale * cos(θ), XY = -scale * sin(θ)
+ * - YX = scale * sin(θ), YY = scale * cos(θ)
+ * - After normalizing: XX ≈ YY and XY ≈ -YX
+ *
+ * For a skew/shear transform, this relationship doesn't hold.
+ */
+export function extractRotationFromTransformMatrix(
+  transformXX: number,
+  transformXY: number,
+  transformYX: number,
+  transformYY: number
+): number | null {
+  // Calculate the scale factors
+  const scaleX = Math.sqrt(
+    transformXX * transformXX + transformXY * transformXY
+  );
+  const scaleY = Math.sqrt(
+    transformYY * transformYY + transformYX * transformYX
+  );
+
+  // Normalize the matrix components to remove scale
+  const normalizedXX = transformXX / scaleX;
+  const normalizedXY = transformXY / scaleX;
+  const normalizedYX = transformYX / scaleY;
+  const normalizedYY = transformYY / scaleY;
+
+  // Check if this is a pure rotation matrix (within tolerance)
+  const tolerance = 0.01;
+  const isRotation =
+    Math.abs(normalizedXX - normalizedYY) < tolerance &&
+    Math.abs(normalizedXY + normalizedYX) < tolerance;
+
+  if (!isRotation) {
+    return null;
+  }
+
+  const angleRadians = -Math.atan2(normalizedYX, normalizedXX);
+  // Return null for negligible rotations
+  if (Math.abs(angleRadians) < 1e-10) {
+    return null;
+  }
+
+  return angleRadians;
+}
+
+/**
+ * Checks if a transform matrix contains a skew/shear component.
+ */
+export function hasSkewTransform(
+  transformXY: number,
+  transformYX: number
+): boolean {
+  return Math.abs(transformXY) > 0.001 || Math.abs(transformYX) > 0.001;
+}


### PR DESCRIPTION
## Summary

- Fixes incorrect rotation being applied to text layers that have skew/shear transforms
- PSD files can have transform matrices that represent skew (faux italic) rather than rotation
- The previous code incorrectly interpreted skew as rotation, applying `atan2(YX, XX)` which resulted in wrong visual output
- CE.SDK doesn't support skew transforms, so we now detect skew vs rotation and only apply actual rotations
- When skew is detected, a warning is logged so integrators know the effect couldn't be preserved

## Technical Details

A 2D transform matrix for pure rotation with scale has the form:
```
XX = scale * cos(θ),  XY = -scale * sin(θ)
YX = scale * sin(θ),  YY = scale * cos(θ)
```

After normalizing to remove scale: `XX ≈ YY` and `XY ≈ -YX`

For skew/shear transforms, this relationship doesn't hold. The fix normalizes the matrix and checks these conditions before applying rotation.

## Test plan

- [x] Verified with `m011t0491_a_world_cup_27nov22.psd` - "TEAM A V/S TEAM B" text no longer incorrectly rotated
- [x] Verified with `rotations.psd` - actual rotated text (-135° to 180°) still renders correctly
- [x] Ran full comparison tests (`npm run compare`) - no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)